### PR TITLE
ci(renovate): move to workflow for org trigger; cleanup workflow

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -20,6 +20,7 @@ src-changed: &src-changed
 renovate-changed:
   - .github/workflows/renovate.yaml
   - .github/renovate.json5
+  - docker/entrypoint.sh
   - action.yaml
 should-check:
   - added|modified: *config

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -170,6 +170,7 @@ jobs:
     needs: [setup, check, test, build]
     outputs:
       commit: ${{ steps.merge.outputs.commit }}
+      published: ${{ steps.semantic-release.outputs.new-release-published }}
       version: ${{ steps.semantic-release.outputs.version }}
     permissions:
       contents: write
@@ -258,11 +259,9 @@ jobs:
             gh api -X PATCH repos/{owner}/{repo}/git/${ref} -f sha=$sha -F force=true
           fi
 
-      - name: Dispatch Renovate workflow in the .github repository
-        if: ${{ env.DRY_RUN != 'true' && steps.semantic-release.outputs.new-release-published == 'true' }}
-        env:
-          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          echo "Triggering workflow_dispatch for $ORG/.github"
-          gh workflow run renovate.yaml --repo $ORG/.github
+  trigger-org-renovate:
+    name: Dispatch Renovate workflow in the .github repository
+    if: github.repository == 'bfra-me/renovate-action' && needs.release.outputs.published == 'true'
+    needs: release
+    secrets: inherit
+    uses: bfra-me/.github/.github/workflows/trigger-org-renovate.yaml@5b99871fcafe4ba4c574449365db1afabb7509d7 # v4.1.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -27,8 +27,8 @@ on:
     workflows: [Main, Update Repo Settings]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -37,26 +37,26 @@ jobs:
   renovate:
     if: >-
       (github.event_name != 'issues' && github.event_name != 'pull_request') ||
+      (github.event_name != 'issues' && contains(github.event.*.labels.*.name, 'renovate')) ||
       (
-        (startsWith(github.head_ref, 'renovate/') || startsWith(github.ref_name, 'renovate/')) &&
-        (
-          contains(join(github.event.*.body, ''), '- [x] <!-- approve-all-pending-prs -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- approve-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- approvePr-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- create-all-rate-limited-prs -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- create-config-migration-pr -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- manual job -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- other-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- rebase-all-open-prs -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- rebase-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- rebase-check -->') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- recreate-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- retry-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- unlimit-branch=') ||
-          contains(join(github.event.*.body, ''), '- [x] <!-- unschedule-branch=')
-        )
+        contains(join(github.event.*.body, ''), '- [x] <!-- approve-all-pending-prs -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- approve-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- approvePr-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- create-all-rate-limited-prs -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- create-config-migration-pr -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- manual job -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- other-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- rebase-all-open-prs -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- rebase-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- rebase-check -->') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- recreate-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- retry-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- unlimit-branch=') ||
+        contains(join(github.event.*.body, ''), '- [x] <!-- unschedule-branch=')
       )
     name: Renovate
+    env:
+      WORKFLOW_LOG_LEVEL: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -64,16 +64,12 @@ jobs:
         if: github.event_name == 'push'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
-          filters: |
-            changes:
-              - '.github/workflows/renovate.yaml'
-              - '.github/renovate.json5'
-              - 'action.yaml'
+          filters: .github/filters.yaml
       - env:
           dry_run: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         if: >-
           (github.event.action == 'edited' && !contains(github.actor, '[bot]')) ||
-          !contains('["push", "workflow_run"]', github.event_name) || github.event.workflow_run.conclusion == 'success' || steps.filter.outputs.changes == 'true'
+          !contains('["push", "workflow_run"]', github.event_name) || github.event.workflow_run.conclusion == 'success' || contains(steps.filter.outputs.changes, 'renovate-changed')
         name: Renovate
         uses: ./
         with:
@@ -81,7 +77,7 @@ jobs:
           cache: true
           dry-run: ${{ env.dry_run }}
           enable-custom-templates: true
-          log-level: ${{ inputs.log-level || (github.event_name == 'pull_request' || github.ref_name != github.event.repository.default_branch) && 'debug' || 'info' }}
-          print-config: ${{ inputs.print-config || false }}
+          log-level: ${{ inputs.log-level || github.event_name == 'pull_request' && 'debug' || env.WORKFLOW_LOG_LEVEL }}
+          print-config: ${{ inputs.print-config }}
           renovate-app-id: ${{ secrets.APPLICATION_ID }}
           renovate-app-private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
- Add docker/entrypoint.sh to renovate-changed filters
- Update concurrency settings in renovate.yaml
- Modify trigger conditions for dispatching Renovate workflow
- Refactor log-level handling in Renovate job