### PR TITLE
feat(config): allow Rust Go and Ruby post-upgrade tasks

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -102,7 +102,12 @@ runs:
               "^(black|ruff format)( --quiet)? \\.$",
               "^ruff check( --fix)?( --quiet)? \\.$",
               "^isort( --profile black)? \\.$",
-              "^pdm (install|lock|update)( --no-self)?$"
+              "^pdm (install|lock|update)( --no-self)?$",
+              "^cargo (update( -p [\\w.-]+)?|build( --locked)?|test( --locked)?)$",
+              "^go mod (tidy|download)$",
+              "^go (generate|test) \\./\\.\\.\\.$",
+              "^gofmt -w \\.$",
+              "^bundle (install( --deployment)?|lock|update [\\w.-]+|exec rubocop -A \\.)$"
             ],
             "description": [
               "Use the global config preset for the @bfra-me organization.",

--- a/action.yaml
+++ b/action.yaml
@@ -103,11 +103,11 @@ runs:
               "^ruff check( --fix)?( --quiet)? \\.$",
               "^isort( --profile black)? \\.$",
               "^pdm (install|lock|update)( --no-self)?$",
-              "^cargo (update( -p [\\w.-]+)?|build( --locked)?|test( --locked)?)$",
+              "^cargo (update( -p [a-zA-Z0-9][\\w.-]*)?|build( --locked)?|test( --locked)?)$",
               "^go mod (tidy|download)$",
               "^go (generate|test) \\./\\.\\.\\.$",
               "^gofmt -w \\.$",
-              "^bundle (install( --deployment)?|lock|update [\\w.-]+|exec rubocop -A \\.)$"
+              "^bundle (install( --deployment)?|lock|update [a-zA-Z0-9][\\w.-]*|exec rubocop -A \\.)$"
             ],
             "description": [
               "Use the global config preset for the @bfra-me organization.",

--- a/src/__tests__/action-config.test.ts
+++ b/src/__tests__/action-config.test.ts
@@ -64,6 +64,13 @@ test('allowedCommands rejects dangerous Rust cargo commands', () => {
   expect(isAllowed(patterns, 'cargo test -- --nocapture')).toBe(false)
 })
 
+test('allowedCommands rejects Cargo package tokens starting with - or .', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'cargo update -p -evil')).toBe(false)
+  expect(isAllowed(patterns, 'cargo update -p .evil')).toBe(false)
+  expect(isAllowed(patterns, 'cargo update -p --workspace')).toBe(false)
+})
+
 // Go ecosystem
 test('allowedCommands allows Go module commands', () => {
   const patterns = extractAllowedCommands()
@@ -96,6 +103,14 @@ test('allowedCommands rejects dangerous Ruby bundler commands', () => {
   expect(isAllowed(patterns, 'bundle update ../../evil')).toBe(false)
   expect(isAllowed(patterns, 'bundle exec rubocop -A .; curl evil')).toBe(false)
   expect(isAllowed(patterns, "bundle exec ruby -e 'system(\"curl evil\")'")).toBe(false)
+})
+
+test('allowedCommands rejects Bundler package tokens starting with - or .', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'bundle update -evil')).toBe(false)
+  expect(isAllowed(patterns, 'bundle update .evil')).toBe(false)
+  expect(isAllowed(patterns, 'bundle update --all')).toBe(false)
+  expect(isAllowed(patterns, 'bundle update --bundler')).toBe(false)
 })
 
 test('global config merge removes user-provided protected fields', () => {

--- a/src/__tests__/action-config.test.ts
+++ b/src/__tests__/action-config.test.ts
@@ -34,6 +34,70 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
+function extractAllowedCommands(): RegExp[] {
+  const config = JSON.parse(extractBaseConfig()) as Record<string, unknown>
+  const patterns = config['allowedCommands']
+  if (!Array.isArray(patterns)) {
+    throw new Error('allowedCommands is not an array')
+  }
+  return (patterns as string[]).map(p => new RegExp(p))
+}
+
+function isAllowed(patterns: RegExp[], command: string): boolean {
+  return patterns.some(re => re.test(command))
+}
+
+// Rust ecosystem
+test('allowedCommands allows Rust cargo commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'cargo update')).toBe(true)
+  expect(isAllowed(patterns, 'cargo update -p serde')).toBe(true)
+  expect(isAllowed(patterns, 'cargo build')).toBe(true)
+  expect(isAllowed(patterns, 'cargo build --locked')).toBe(true)
+  expect(isAllowed(patterns, 'cargo test --locked')).toBe(true)
+})
+
+test('allowedCommands rejects dangerous Rust cargo commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'cargo update -p ../../evil')).toBe(false)
+  expect(isAllowed(patterns, 'cargo build; curl evil')).toBe(false)
+  expect(isAllowed(patterns, 'cargo test -- --nocapture')).toBe(false)
+})
+
+// Go ecosystem
+test('allowedCommands allows Go module commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'go mod tidy')).toBe(true)
+  expect(isAllowed(patterns, 'go mod download')).toBe(true)
+  expect(isAllowed(patterns, 'go generate ./...')).toBe(true)
+  expect(isAllowed(patterns, 'gofmt -w .')).toBe(true)
+  expect(isAllowed(patterns, 'go test ./...')).toBe(true)
+})
+
+test('allowedCommands rejects dangerous Go commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'go generate ./...; curl evil')).toBe(false)
+  expect(isAllowed(patterns, 'gofmt -w ../evil.go')).toBe(false)
+  expect(isAllowed(patterns, 'go test ./... -exec sh')).toBe(false)
+})
+
+// Ruby ecosystem
+test('allowedCommands allows Ruby bundler commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'bundle install')).toBe(true)
+  expect(isAllowed(patterns, 'bundle install --deployment')).toBe(true)
+  expect(isAllowed(patterns, 'bundle lock')).toBe(true)
+  expect(isAllowed(patterns, 'bundle update rails')).toBe(true)
+  expect(isAllowed(patterns, 'bundle exec rubocop -A .')).toBe(true)
+})
+
+test('allowedCommands rejects dangerous Ruby bundler commands', () => {
+  const patterns = extractAllowedCommands()
+  expect(isAllowed(patterns, 'bundle update ../../evil')).toBe(false)
+  expect(isAllowed(patterns, 'bundle exec rubocop -A .; curl evil')).toBe(false)
+  expect(isAllowed(patterns, "bundle exec ruby -e 'system(\"curl evil\")'")).toBe(false)
+})
+
 test('global config merge removes user-provided protected fields', () => {
   const script = `${extractConfigureScript()}
 merge_global_config "$BASE_CONFIG" "$USER_CONFIG"


### PR DESCRIPTION
## Summary

- Add Renovate `postUpgradeTasks` allowlist coverage for Rust, Go, and Ruby maintenance commands.
- Keep command patterns anchored and limited to safe flags, package names, and current-directory targets.
- Add tests that assert supported commands are allowed while traversal, shell metacharacters, and execution escape hatches are rejected.

## Verification

- `pnpm bootstrap && pnpm build && pnpm check && pnpm test`
- `pnpm check && pnpm test`